### PR TITLE
Compute TFIDF over type usage

### DIFF
--- a/bin/discovery_model/compute_tfidf.dart
+++ b/bin/discovery_model/compute_tfidf.dart
@@ -1,0 +1,54 @@
+// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io' as io;
+import 'dart:convert';
+import 'dart:math' as math;
+
+Map<String, Map<String, int>> typeIndex = {};
+Map<String, Map<String, num>> typeTFIDF = {};
+
+int numberOfDocuments = 0;
+const DIAGNOSTICS = false;
+
+/// Export the tfidf for the results of the typeusage_reducer
+main(List<String> args) {
+  if (args.length != 1) {
+    print("Usage: compute_tfidf [path_to_features_file]");
+    io.exit(1);
+  }
+  typeIndex = JSON.decode(new io.File(args[0]).readAsStringSync());
+
+  // Compute the number of documents
+  var corpusSet = new Set();
+  for (var k in typeIndex.keys) {
+    corpusSet.addAll(typeIndex[k].keys);
+  }
+
+  numberOfDocuments = corpusSet.length;
+
+  // Computing TF-IDF table
+  for (String k in typeIndex.keys) {
+    typeTFIDF.putIfAbsent(k, () => {});
+    var inverseFreq = math.log(numberOfDocuments / typeIndex[k].length);
+    for (var kk in typeIndex[k].keys) {
+      typeTFIDF[k][kk] = typeIndex[k][kk] * inverseFreq;
+    }
+  }
+
+  typeIndex = null;
+
+  if (DIAGNOSTICS) {
+    for (var k in typeTFIDF.keys) {
+      print(k);
+      var tdfifKeys = typeTFIDF[k].keys.toList()
+        ..sort((a, b) => typeTFIDF[k][a].compareTo(typeTFIDF[k][b]));
+      for (var kk in tdfifKeys.reversed) {
+        print(" $kk ${typeTFIDF[k][kk]}");
+      }
+    }
+  }
+
+  print(JSON.encode(typeTFIDF));
+}

--- a/bin/discovery_model/typeusage_reducer.dart
+++ b/bin/discovery_model/typeusage_reducer.dart
@@ -24,6 +24,10 @@ main(List<String> args) {
     var data = JSON.decode(f.readAsStringSync());
     for (var dataPath in data['result'].keys) {
 
+      // TODO: This form of path mangling should be replaced with something
+      // that reads the input field of the results to give a stable mapping
+      // to their source
+
       var fileName =
         f.path.split("2016-01").last + dataPath.split("data_working").last;
       var discoveryFeatures = data['result'][dataPath]['discovery_features'];

--- a/bin/discovery_model/typeusage_reducer.dart
+++ b/bin/discovery_model/typeusage_reducer.dart
@@ -1,0 +1,38 @@
+// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io' as io;
+import 'dart:convert';
+
+Map<String, Map<String, int>> typeIndex = {};
+
+/// Export the type usage distribution from the results of the map
+main(List<String> args) {
+  if (args.length != 1) {
+    print ("Usage: typeusage_reducer [path_to_features]");
+    io.exit(1);
+  }
+
+  List<io.FileSystemEntity> fses =
+    new io.Directory(args[0]).listSync(recursive: true);
+
+  for (var fse in fses) {
+    if (!fse.path.endsWith(".gz")) continue;
+
+    var f = fse as io.File;
+    var data = JSON.decode(f.readAsStringSync());
+    for (var dataPath in data['result'].keys) {
+
+      var fileName =
+        f.path.split("2016-01").last + dataPath.split("data_working").last;
+      var discoveryFeatures = data['result'][dataPath]['discovery_features'];
+      for (var typeUsageKV in discoveryFeatures) {
+        var type = typeUsageKV['TypeUsage'];
+        typeIndex.putIfAbsent(type, () => {}).putIfAbsent(fileName, () => 0);
+        typeIndex[type][fileName]++;
+      }
+    }
+  }
+  print (JSON.encode(typeIndex));
+}

--- a/worker_isolate.dart
+++ b/worker_isolate.dart
@@ -130,10 +130,12 @@ Future processFile(AuthClient client, String projectName, String bucketName,
   var discoveryResults = await discovery_model.analyseFolder(workingDirectory.path);
 
   var results = {};
-  results.addAll(completionResults);
-  results.addAll(discoveryResults);
-
-  // var results = [workingDirectory.path];
+  for (var fileKey in completionResults.keys) {
+    results.putIfAbsent(fileKey, () => {}).addAll(completionResults[fileKey]);
+  }
+  for (var fileKey in discoveryResults.keys) {
+    results.putIfAbsent(fileKey, () => {}).addAll(discoveryResults[fileKey]);
+  }
 
   log.info("Cleaning up");
   log.info("Deleting working directory");


### PR DESCRIPTION
TBR @emsod This adds a basic computation of [tf-idf](https://en.wikipedia.org/wiki/Tf%E2%80%93idf) to build a basic document score.

This is only building a very minimal model of document relevance based on type usage, an object protocol or a ngram type model would be a good thing to add in future work.

On current corpus sizes this code executes sufficiently quickly.

I haven't forgotten your previous request for a little more documentation. Will follow up.

CC @danrubel @sgjesse 