### PR TITLE
Improve the data structures for feature storage

### DIFF
--- a/bin/completion_model/completion_reducer.dart
+++ b/bin/completion_model/completion_reducer.dart
@@ -1,0 +1,75 @@
+// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io' as io;
+import 'dart:convert' as convert;
+
+import 'package:smart/completion_model/feature_vector.dart';
+import 'package:smart/completion_server/feature_server.dart';
+
+import 'package:path/path.dart' as path;
+
+main(List<String> args) {
+  if (args.length != 2) {
+    print('Usage: completion_reducer features_path out_path');
+    print(
+    """This tool processes the results of the completion extractors and
+       emits the packed file formats for the feature_server to load""");
+    io.exit(1);
+  }
+
+  Stopwatch sw = new Stopwatch()..start();
+
+  String inPath = args[0];
+  print('in path: $inPath');
+
+  String outPath = args[1];
+  print('out path: $outPath');
+
+  io.Directory inDir = new io.Directory(inPath);
+
+  num i = 0;
+  List<io.FileSystemEntity> fses = inDir.listSync(recursive: true);
+  num max = fses.length.toDouble();
+
+  FeatureServer model = new FeatureServer();
+
+  // targetType -> Completion -> Files
+  // This map is exported to assist with debugging
+  Map<String, Map<String, List<String>>> featureProvenence = {};
+
+  for (io.FileSystemEntity f in fses) {
+    i++;
+    if (f is io.File) {
+      if (f.path.endsWith(".gz") && !f.path.contains("gstmp")) {
+        print("${sw.elapsedMilliseconds}: ${i/max}: ${f.path}");
+
+        var data = convert.JSON.decode(f.readAsStringSync());
+        data = data['result'];
+
+        for (var path in data.keys) {
+          var completionFeatures = data[path]['completion_features'];
+          if (completionFeatures == null) continue;
+          for (var completionFeatureString in completionFeatures) {
+            // Load the Feature Vector from the string
+            var vector =
+                new FeatureVector().fromJsonString(completionFeatureString);
+            model.addFeature(vector);
+
+            featureProvenence
+                .putIfAbsent(vector.targetType, () => {})
+                .putIfAbsent(vector.completion, () => [])
+                .add(f.path);
+          }
+        }
+      }
+    }
+  }
+
+  model.toPath(path.join(outPath, "completion_count.json"),
+      path.join(outPath, "packed_model.smart_complete"));
+
+  new io.File(path.join(outPath, "featureProvenence.json"))
+      .writeAsStringSync(convert.JSON.encode(featureProvenence));
+}

--- a/bin/completion_model/local_extractor_driver.dart
+++ b/bin/completion_model/local_extractor_driver.dart
@@ -1,0 +1,22 @@
+// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:smart/completion_model/analyse_path.dart' as completion_model;
+import 'dart:io' as io;
+import 'package:sintr_common/logging_utils.dart' as log;
+
+
+main(List<String> args) {
+  log.setupLogging();
+
+  if (args.length != 1) {
+    print ("Usage dart local_extractor_driver.dart path");
+    print ("Diagnostics tool for debugging features from a given path");
+    io.exit(1);
+  }
+
+  var result = completion_model.analyseFolder(args[0]);
+  print (result);
+
+}

--- a/lib/completion_model/ast_extractors.dart
+++ b/lib/completion_model/ast_extractors.dart
@@ -2,15 +2,16 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE.md file.
 
+/// This provides helpers for systematically extracting the structures used
+/// for completion from the different ASTs
 library smart.completion_models.ast_extractors;
 
 import 'package:analyzer/src/generated/ast.dart' as ast;
 
 import 'ast_features.dart';
+import 'feature_vector.dart';
 
-const COMPLETION_KEY_NAME = "**Completion";
-
-Map featuresFromPrefixedIdentifier(ast.PrefixedIdentifier node) {
+FeatureVector featuresFromPrefixedIdentifier(ast.PrefixedIdentifier node) {
   // TODO(lukechurch): Address the below from the completion logic:
   // "some PrefixedIdentifier nodes are transformed into
   // ConstructorName nodes during the resolution process."
@@ -20,33 +21,33 @@ Map featuresFromPrefixedIdentifier(ast.PrefixedIdentifier node) {
 
   if (realTarget != null) {
     var invocation = extractFeaturesForTarget(realTarget, node);
-    invocation.putIfAbsent(COMPLETION_KEY_NAME, () => "$completion");
+    invocation.completion = completion;
     return invocation;
   }
 
   return null;
 }
 
-Map featuresFromPropertyAccess(ast.PropertyAccess node) {
+FeatureVector featuresFromPropertyAccess(ast.PropertyAccess node) {
   var realTarget = node.realTarget;
   var completion = node.propertyName;
 
   if (realTarget != null) {
     var invocation = extractFeaturesForTarget(realTarget, node);
-    invocation.putIfAbsent(COMPLETION_KEY_NAME, () => "$completion");
+    invocation.completion = completion;
     return invocation;
   }
 
   return null;
 }
 
-Map featuresFromMethodInvocation(ast.MethodInvocation node) {
+FeatureVector featuresFromMethodInvocation(ast.MethodInvocation node) {
   var realTarget = node.realTarget;
   var completion = node.methodName;
 
   if (realTarget != null) {
     var invocation = extractFeaturesForTarget(realTarget, node);
-    invocation.putIfAbsent(COMPLETION_KEY_NAME, () => "$completion");
+    invocation.completion = completion;
     return invocation;
   }
 

--- a/lib/completion_model/ast_features.dart
+++ b/lib/completion_model/ast_features.dart
@@ -6,58 +6,52 @@ library smart.completion_model.ast_features;
 
 import 'package:analyzer/src/generated/ast.dart' as ast;
 import '../analysis_utils/type_utils.dart';
+import 'feature_vector.dart' as features;
 
 /// Extract features for an ast construct with a target
-Map extractFeaturesForTarget(ast.Expression realTarget, ast.AstNode node) {
-  var bestType = realTarget.bestType;
-  String targetTypeName = TypeUtils.qualifiedName(bestType.element);
+features.FeatureVector extractFeaturesForTarget(ast.Expression realTarget, ast.AstNode node) {
+  var vector = new features.FeatureVector();
 
-  Map featuresAccumlator = extractFeaturesForNode(node);
-  Map featuresFromTarget = {
-    "TargetType": "$targetTypeName",
-    "TargetName": "${realTarget}",
-    "TargetRuntimeType": "${realTarget.runtimeType}",
-  };
-  featuresAccumlator.addAll(featuresFromTarget);
-  return featuresAccumlator;
+  var bestType = realTarget.bestType;
+  vector.targetType = TypeUtils.qualifiedName(bestType.element);
+  _extractFeaturesForNode(node, vector);
+
+  return vector;
 }
 
 /// Extract features that apply to all AstNodes
-Map extractFeaturesForNode(ast.AstNode node) {
-  var features = {
-    "InClass": _inClass(node),
-    "InMethod": _inMethod(node),
-    "InFunction": _inFunction(node),
-    "InFunctionStatement": _inFunctionStatement(node),
-    "InTry": _inTry(node),
-    "InCatch": _inCatch(node),
-    "InICE": _inICE(node),
-    "InFormalParam": _inFormalParameter(node),
-    "InAssignment": _inAssignment(node),
-    "InConditional": _inConditionalExpression(node),
-    "InForEachLoop": _inForEachLoop(node),
-    "InForLoop": _inForLoop(node),
-    "InWhileLoop": _inWhileLoop(node),
-    "InReturnStatement": _inReturnStatement(node),
-    "InStringInterpolation": _inStringInterpolation(node),
-    "InStaticMethod": _inStaticMethod(node),
-    "InAsyncMethod": _inAsyncMethod(node),
-    "InSyncMethod": _inSyncMethod(node),
-    "InGeneratorMethod": _inGeneratorMethod(node),
-    "InAssertStatement": _inAssertStatement(node),
-    "InAwaitExpression": _inAwaitExpression(node),
-    "InTestMethodInvocation": _insideInvocationStartsWith(node, "test"),
-    "InDescribeMethodInvocation": _insideInvocationStartsWith(node, "describe"),
-    "InMainMethodDeclaration": _insideDeclarationStartsWith(node, "main"),
-    "InTestMethodDeclaration": _insideDeclarationStartsWith(node, "test"),
-    "InDeclarationWithSet": _insideDeclarationStartsWith(node, "set"),
-    "InDeclarationWithGet": _insideDeclarationStartsWith(node, "get"),
-    "InDeclarationWithHas": _insideDeclarationStartsWith(node, "has"),
-    "InDeclarationWithIs": _insideDeclarationStartsWith(node, "is"),
-    "assigmmentLHSStaticType": _assignmentType(node)
-  };
+_extractFeaturesForNode(ast.AstNode node, features.FeatureVector vector) {
+  vector.setValue(features.IN_CLASS_NAME, _inClass(node));
+  vector.setValue(features.IN_METHOD_NAME, _inMethod(node));
+  vector.setValue(features.IN_FUNCTION_NAME, _inFunction(node));
+  vector.setValue(features.IN_FUNCTION_STATEMENT_NAME, _inFunctionStatement(node));
+  vector.setValue(features.IN_TRY_NAME, _inTry(node));
+  vector.setValue(features.IN_CATCH_NAME, _inCatch(node));
+  vector.setValue(features.IN_ICE_NAME, _inICE(node));
+  vector.setValue(features.IN_FORMAL_PARAM_NAME, _inFormalParameter(node));
+  vector.setValue(features.IN_ASSIGN_NAME, _inAssignment(node));
+  vector.setValue(features.IN_COND_NAME, _inConditionalExpression(node));
+  vector.setValue(features.IN_FOREACH_NAME, _inForEachLoop(node));
+  vector.setValue(features.IN_FOR_NAME, _inForLoop(node));
+  vector.setValue(features.IN_WHILE_NAME, _inWhileLoop(node));
+  vector.setValue(features.IN_RETURN_NAME, _inReturnStatement(node));
+  vector.setValue(features.IN_STRING_INTERPOL_NAME, _inStringInterpolation(node));
+  vector.setValue(features.IN_STATIC_NAME, _inStaticMethod(node));
+  vector.setValue(features.IN_ASYNC_NAME, _inAsyncMethod(node));
+  vector.setValue(features.IN_SYNC_NAME, _inSyncMethod(node));
+  vector.setValue(features.IN_GENERATOR_NAME, _inGeneratorMethod(node));
+  vector.setValue(features.IN_ASSRT_NAME, _inAssertStatement(node));
+  vector.setValue(features.IN_AWAIT_NAME, _inAwaitExpression(node));
+  vector.setValue(features.IN_TEST_INVOCATION_NAME, _insideInvocationStartsWith(node, "test"));
+  vector.setValue(features.IN_DESCRIBE_NAME, _insideInvocationStartsWith(node, "describe"));
+  vector.setValue(features.IN_MAIN_NAME, _insideDeclarationStartsWith(node, "main"));
+  vector.setValue(features.IN_TEST_METHOD_NAME, _insideDeclarationStartsWith(node, "test"));
+  vector.setValue(features.IN_DECLARATION_WITH_SET_NAME, _insideDeclarationStartsWith(node, "set"));
+  vector.setValue(features.IN_DECLARATION_WITH_GET_NAME, _insideDeclarationStartsWith(node, "get"));
+  vector.setValue(features.IN_DECLARATION_WITH_HAS_NAME, _insideDeclarationStartsWith(node, "has"));
+  vector.setValue(features.IN_DECLARATION_WITH_IS_NAME, _insideDeclarationStartsWith(node, "is"));
+  vector.setValue(features.ASSIGNMENT_LHS_STATIC, _assignmentType(node));
 
-  return features;
 }
 
 // Helper methods, once we're confident that these are sampling the

--- a/lib/completion_model/feature_extractor.dart
+++ b/lib/completion_model/feature_extractor.dart
@@ -10,6 +10,7 @@ import 'package:sintr_common/logging_utils.dart' as log;
 
 import '../analysis_utils/analysis_utils.dart' as analysis_utils;
 import 'ast_extractors.dart' as extractors;
+import 'feature_vector.dart';
 
 
 // TODO(luekchurch): Refactor this so it shares an implementation with the
@@ -21,7 +22,7 @@ class Analysis {
     JavaSystemIO.setProperty("com.google.dart.sdk", sdkPath);
   }
 
-  List<Map> analyzeSpecificFile(String path) {
+  List<FeatureVector> analyzeSpecificFile(String path) {
     log.trace("analyzeSpecificFile: $path");
     sw = new Stopwatch()..start();
 
@@ -40,26 +41,23 @@ class Analysis {
 }
 
 class FeatureExtractor extends GeneralizingAstVisitor {
-  var features = [];
+  List<FeatureVector> features = [];
 
   @override
   visitPrefixedIdentifier(PrefixedIdentifier node) {
-    Map featuresMap = extractors.featuresFromPrefixedIdentifier(node);
-    features.add(featuresMap);
+    features.add(extractors.featuresFromPrefixedIdentifier(node));
     return super.visitNode(node);
   }
 
   @override
   visitPropertyAccess(PropertyAccess node) {
-    Map featuresMap = extractors.featuresFromPropertyAccess(node);
-    features.add(featuresMap);
+    features.add(extractors.featuresFromPropertyAccess(node));
     return super.visitNode(node);
   }
 
   @override
   visitMethodInvocation(MethodInvocation node) {
-    Map featuresMap = extractors.featuresFromMethodInvocation(node);
-    features.add(featuresMap);
+    features.add(extractors.featuresFromMethodInvocation(node));
     return super.visitNode(node);
   }
 }

--- a/lib/completion_model/feature_vector.dart
+++ b/lib/completion_model/feature_vector.dart
@@ -1,0 +1,262 @@
+// Copyright (c) 2016, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE.md file.
+
+// TOOD: Use binary search not indexOf to improve lookup performance
+
+/// Memory efficent representation of the feature vectors and the aggregated
+/// distribution statistics over the features
+library smart.completion_model.feature_vector;
+
+import 'dart:typed_data' as typd;
+import 'dart:convert';
+
+// Binary features
+const IN_CLASS_NAME = "InClass";
+const IN_METHOD_NAME = "InMethod";
+const IN_FUNCTION_NAME = "InFunction";
+const IN_FUNCTION_STATEMENT_NAME = "InFunctionStatement";
+const IN_TRY_NAME = "InTry";
+const IN_CATCH_NAME = "InCatch";
+const IN_ICE_NAME = "InICE";
+const IN_FORMAL_PARAM_NAME = "InFormalParam";
+const IN_ASSIGN_NAME = "InAssignment";
+const IN_COND_NAME = "InConditional";
+const IN_FOREACH_NAME = "InForEachLoop";
+const IN_FOR_NAME = "InForLoop";
+const IN_WHILE_NAME = "InWhileLoop";
+const IN_RETURN_NAME = "InReturnStatement";
+const IN_STRING_INTERPOL_NAME = "InStringInterpolation";
+const IN_STATIC_NAME = "InStaticMethod";
+const IN_ASYNC_NAME = "InAsyncMethod";
+const IN_SYNC_NAME = "InSyncMethod";
+const IN_GENERATOR_NAME = "InGeneratorMethod";
+const IN_ASSRT_NAME = "InAssertStatement";
+const IN_AWAIT_NAME = "InAwaitExpression";
+const IN_TEST_INVOCATION_NAME = "InTestMethodInvocation";
+const IN_DESCRIBE_NAME = "InDescribeMethodInvocation";
+const IN_MAIN_NAME = "InMainMethodDeclaration";
+const IN_TEST_METHOD_NAME = "InTestMethodDeclaration";
+const IN_DECLARATION_WITH_SET_NAME = "InDeclarationWithSet";
+const IN_DECLARATION_WITH_GET_NAME = "InDeclarationWithGet";
+const IN_DECLARATION_WITH_HAS_NAME = "InDeclarationWithHas";
+const IN_DECLARATION_WITH_IS_NAME = "InDeclarationWithIs";
+
+// Non-binary features
+const ASSIGNMENT_LHS_STATIC = "assigmmentLHSStaticType";
+
+/// Storage class for a statically defined set of features, either of binary or
+/// string types
+class FeatureVector {
+  static const int VERSION = 0;
+
+  List<bool> binaryFeatureValues;
+  /// [binaryFeatureNames] is a constant list of the binary features. To add
+  /// a feature add its name to this list via a constant
+  /// and increment the VERSION above
+  static const List<String> binaryFeatureNames = const <String>[
+    IN_CLASS_NAME,
+    IN_METHOD_NAME,
+    IN_FUNCTION_NAME,
+    IN_FUNCTION_STATEMENT_NAME,
+    IN_TRY_NAME,
+    IN_CATCH_NAME,
+    IN_ICE_NAME,
+    IN_FORMAL_PARAM_NAME,
+    IN_ASSIGN_NAME,
+    IN_COND_NAME,
+    IN_FOREACH_NAME,
+    IN_FOR_NAME,
+    IN_WHILE_NAME,
+    IN_RETURN_NAME,
+    IN_STRING_INTERPOL_NAME,
+    IN_STATIC_NAME,
+    IN_ASYNC_NAME,
+    IN_SYNC_NAME,
+    IN_GENERATOR_NAME,
+    IN_ASSRT_NAME,
+    IN_AWAIT_NAME,
+    IN_TEST_INVOCATION_NAME,
+    IN_DESCRIBE_NAME,
+    IN_MAIN_NAME,
+    IN_TEST_METHOD_NAME,
+    IN_DECLARATION_WITH_SET_NAME,
+    IN_DECLARATION_WITH_GET_NAME,
+    IN_DECLARATION_WITH_HAS_NAME,
+    IN_DECLARATION_WITH_IS_NAME,
+  ];
+
+  Map<String, String> stringFeatureValues = {};
+
+  FeatureVector() {
+    binaryFeatureValues = new List(binaryFeatureNames.length);
+  }
+
+  /// Get the value for the feature or null if the feature isn't defined
+  dynamic getValue(String name) {
+    int featureIndex = binaryFeatureNames.indexOf(name);
+    if (featureIndex != -1) return binaryFeatureValues[featureIndex];
+    return stringFeatureValues[name];
+  }
+
+  // TODO: Replace this with a compound iterator to eliminate the
+  // copy cost
+  Iterable<String> get allFeatureNames {
+    List<String> accumulator = <String>[];
+    accumulator.addAll(binaryFeatureNames);
+    accumulator.addAll(stringFeatureValues.keys);
+
+    return accumulator;
+  }
+
+  setValue(String name, dynamic value) {
+    if (value is bool) {
+      setBinaryValue(name, value);
+    } else {
+      setStringValue(name, "$value");
+    }
+  }
+
+  setBinaryValue(String name, bool value) {
+    int featureIndex = binaryFeatureNames.indexOf(name);
+
+    if (featureIndex == -1)
+      throw "Unknown feature";
+
+    binaryFeatureValues[featureIndex] = value;
+  }
+
+  setStringValue(String name, String value) {
+    stringFeatureValues[name] = value;
+  }
+
+  // Special properties, these are not features
+  var _completion;
+  var _targetType;
+
+  // TODO: Use fully qualified type name?
+  String get targetType => "$_targetType";
+  String get completion => "$_completion";
+
+  String toJsonString() {
+    var obj = {
+        "VERSION" : VERSION,
+        "completion" : "$_completion",
+        "targetType" : "$_targetType",
+        "binaryFeatureValues" : binaryFeatureValues,
+        "stringFeatureValues" : stringFeatureValues
+      };
+      return JSON.encode(obj);
+  }
+
+  FeatureVector fromJsonString(String json) {
+    Map decoded = JSON.decode(json);
+    if (decoded["VERSION"] != VERSION) {
+      throw "Incompatible versions, source: $VERSION, json: ${decoded['VERSION']}";
+    }
+
+    FeatureVector vector = new FeatureVector();
+    vector._completion = decoded['completion'];
+    vector._targetType = decoded['targetType'];
+
+    List<bool> decodedBinaryFeatureValues = decoded['binaryFeatureValues'];
+    if (decodedBinaryFeatureValues.length != binaryFeatureNames.length)
+      throw "Source data was of the wrong size";
+    vector.binaryFeatureValues = decodedBinaryFeatureValues;
+
+    for (String featureName in decoded['stringFeatureValues'].keys) {
+      vector.stringFeatureValues[featureName]
+        = decoded['stringFeatureValues'][featureName];
+    }
+
+    return vector;
+  }
+}
+
+/// Memory efficent representation of counts over the feature vector structure
+/// above. O(n * m) of these will be needed for n types and m completions
+class FeatureValueDistribution {
+  typd.Uint32List _binaryFeatureCount
+    = new typd.Uint32List(FeatureVector.binaryFeatureNames.length * 2);
+
+  Map<String, Map<String, int>> _featuresCountMap = {};
+
+  incrementFeatureValueCount(String featureName, dynamic value) {
+    var currentValue = getFeatureValueCount(featureName, value);
+    if (currentValue == null) currentValue = 0;
+    setFeatureValueCount(featureName, value, currentValue + 1);
+  }
+
+  int getTotalCountForFeature(String featureName) {
+    int featureIndex = FeatureVector.binaryFeatureNames.indexOf(featureName);
+    if (featureIndex != -1) {
+      int valueIndex = featureIndex * 2;
+      int count = _binaryFeatureCount[valueIndex] // Value for false
+        + _binaryFeatureCount[valueIndex+1];      // Value for true
+      return count;
+    }
+    var featureValuesMap = _featuresCountMap[featureName];
+    if (featureValuesMap == null) return 0;
+
+    return featureValuesMap.values.fold(0, (a, b) => a + b);
+  }
+
+  int getFeatureValueCount(String featureName, dynamic value) {
+    int featureIndex = FeatureVector.binaryFeatureNames.indexOf(featureName);
+    if (featureIndex != -1) {
+      // This was a binary feature, return value for false, second for true
+      int valueIndex = featureIndex * 2 + (value as bool ? 1 : 0);
+      return _binaryFeatureCount[valueIndex];
+    }
+    var featureValuesMap = _featuresCountMap[featureName];
+    if (featureValuesMap == null) return 0;
+
+    return featureValuesMap["$value"];
+  }
+
+  setFeatureValueCount(String featureName, dynamic value, int count) {
+    int featureIndex = FeatureVector.binaryFeatureNames.indexOf(featureName);
+    if (featureIndex != -1) {
+      _binaryFeatureCount[featureIndex * 2 + (value as bool ? 1 : 0)] = count;
+      return;
+    }
+
+    _featuresCountMap.putIfAbsent(featureName, () => {})[value] = count;
+  }
+
+  // == Serialisation support methods ==
+  // Binary features will have two values, each of 4 bytes
+  int get _expectedFeatureCountByteCount  =>
+    FeatureVector.binaryFeatureNames.length * 2 * 4;
+
+  List<int> toStorageByteBlock() {
+    typd.Uint8List byteBlockForFeatureCount =
+      _binaryFeatureCount.buffer.asUint8List();
+
+    if (byteBlockForFeatureCount.length !=
+      _expectedFeatureCountByteCount)
+      throw "ByteBlock length was unexpected";
+
+    var mergedByteBlock = new List<int>();
+    mergedByteBlock.addAll(byteBlockForFeatureCount);
+    mergedByteBlock.addAll(UTF8.encode(JSON.encode(_featuresCountMap)));
+    return mergedByteBlock;
+  }
+
+  FeatureValueDistribution.fromStorageBlock(List<int> block) {
+
+    typd.Uint8List byteBlock = new typd.Uint8List.fromList(
+      block.sublist(0, _expectedFeatureCountByteCount)
+    );
+
+    _binaryFeatureCount.setAll(0, byteBlock.buffer.asUint32List());
+
+    // Read the feature blocks
+    // binaryFeatureCount.setRange(0, _expectedFeatureCountByteCount, byteBlock.buffer.asUint32List());
+    _featuresCountMap =
+      JSON.decode(UTF8.decode(block.skip(_expectedFeatureCountByteCount).toList()));
+  }
+
+  // Default ctor creates an empty distribution
+  FeatureValueDistribution() { }
+}

--- a/lib/completion_model/model.dart
+++ b/lib/completion_model/model.dart
@@ -1,197 +1,131 @@
-// Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
-// for details. All rights reserved. Use of this source code is governed by a
-// BSD-style license that can be found in the LICENSE file.
-
+// // Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// // for details. All rights reserved. Use of this source code is governed by a
+// // BSD-style license that can be found in the LICENSE file.
+//
 library smart.completion_model.model;
 
-import '../completion_server/feature_server.dart';
-import '../completion_server/log_client.dart' as log_client;
+import 'package:smart/completion_server/feature_server.dart';
+import 'package:smart/completion_server/log_client.dart' as log_client;
 
-import 'dart:io' as io;
 import 'package:logging/logging.dart' as log;
-import 'ast_extractors.dart';
-
+import 'feature_vector.dart';
 
 const ENABLE_DIAGNOSTICS = false;
-const DISABLED_FEATURES = const [];
 
+/// [Model] encapsulates the Bayesian model for using the features to
+/// predict an ordering on completions
 class Model {
   int modelSwitchThreshold;
   num smoothingFactor;
   FeatureServer server;
   log.Logger _logger;
 
-  // Cache the model data
-  //targetType -> feature -> completionResult -> featureValue__count
-  // var dataModel;
-
-  //targetType -> completionResult -> count
-  // Map<String, Map<String, num>> targetTypeCompletionCount;
-
-  Model(String featuresPath,
+  Model(this.server,
       [this.modelSwitchThreshold = 3, this.smoothingFactor = 0.0000001]) {
-        _logger = new log.Logger("smart.completion_model.model");
-        log_client.bindLogServer(_logger);
-
-        _logger.info("About to start feature server: $featuresPath");
-    server = FeatureServer.startFromPath(featuresPath);
+    _logger = new log.Logger("smart.completion_model.model");
+    log_client.bindLogServer(_logger);
   }
 
-  Map<String, Map<String, num>> scoreCompletionOrder(var featureMap) {
-    _logger.fine("scoreCompletionOrder: $featureMap");
+  /// Returns a sorted list of completions in increasing order of probability.
+  List<CompletionResult> scoreCompletionOrder(FeatureVector vector) {
+    /*
+    The probability distribution is separated for each type
 
-    /* The probability of the completion 'toString' being accepted correlates to:
+    The probability of the completion 'toString' being accepted correlates to:
     P(completion == "toString" | context) ~=
       P(completion == "toString) *
       P(inClass == context[inClass] | completion == "toString") *
       P(... == context[...] | completion == "toString") *
       ...
-     */
+    */
 
-    Map<String, Map<String, num>> completionScores = {};
-
-    // Get a list of completions that we've seen for this type
-    var targetType = featureMap["TargetType"];
-    var serverMap = server.getFeaturesFor(targetType);
-
-    if (targetType == null ||
-        serverMap == null ||
-        serverMap.completionResult_count == null) {
-      _logger.info("Type not seen before: $targetType, "
-          "${serverMap == null} "
-          "${serverMap.completionResult_count == null}");
-
-      // We've never seen this type before, this simple model should just
-      // return a uniform model
-      return null;
+    if (vector.targetType == null) {
+      _logger.info("Target type null, return uniform probability");
+      return [];
     }
 
-    var completionResultsMap = serverMap.completionResult_count;
+    // The global probability is estimated based purely on relative frequency
+    // This map will serve as the data source
+    Map<String, int> completionCount =
+        server.getCompletionCount(vector.targetType);
 
-    List<String> seenCompletions = completionResultsMap.keys.toList();
-    num totalSeenCount = completionResultsMap.values.reduce(sum);
+    if (completionCount == null) {
+      _logger.info("Target type null, return uniform probability");
+      return [];
+    }
 
-    for (String completion in seenCompletions) {
-      completionScores.putIfAbsent(completion, () => {});
 
-      // Compute P(c == completion)
-      num pCompletion = completionResultsMap[completion] / totalSeenCount;
-      completionScores[completion]["pCompletion"] = pCompletion;
+    Map<String, FeatureValueDistribution> completionFeatureDistribution =
+        server.getCompletionFeatureValues(vector.targetType);
 
-      num pFeatures = 1;
-      // Compute the other features
-      for (String featureName in featureMap.keys) {
-        if (featureName == "TargetType" ||
-            featureName == COMPLETION_KEY_NAME) continue;
+    final int totalCompletionsSeenForThisTarget =
+        completionCount.values.fold(0, (a, b) => a + b);
 
-        // Skip any features that are disabled in the model
-        if (DISABLED_FEATURES.contains(featureName)) continue;
+    List<CompletionResult> results = <CompletionResult>[];
 
-        // Lookup the value for this feature for completion query
-        var featureValue = "${featureMap[featureName]}";
+    for (String completion in completionCount.keys) {
+      CompletionResult result = new CompletionResult();
 
-        // targetType -> feature -> completionResult -> featureValue :: count
-        // Lookup this value in the main model
-        Map<dynamic, num> featureValue__count =
-            serverMap.featureName_completionResult_featureValue_count[
-                featureName][completion];
+      result.completion = completion;
 
-        // For the given [completion] the counts of the feature values are now
-        // in featureValue__count
+      // P(c == completion)
+      num score =
+          completionCount[completion] / totalCompletionsSeenForThisTarget;
+      result.featureValues["_P(completion)"] = score;
 
-        // If this is null, it's because this part of the model has been pruned
-        // We can simulate this by creating an empty map
-        if (featureValue__count == null) featureValue__count = {};
+      var featureDistribution = completionFeatureDistribution[completion];
 
-        // Compute the total for this feature value
-        num totalForThisValue = featureValue__count.values.reduce(sum);
+      // Compute probabilities for each of the features
+      for (var featureName in vector.allFeatureNames) {
+        // feature value from the completion request
+        var featureValue = vector.getValue(featureName);
+        int totalCountForFeature =
+            featureDistribution.getTotalCountForFeature(featureName);
 
-        // P(this feature)
-        num pFeature = 1;
+        int countForFeatureValue =
+            featureDistribution.getFeatureValueCount(featureName, featureValue);
 
-        String featureLookup = "$featureName = $featureValue";
+        if (countForFeatureValue == null) countForFeatureValue = 0;
 
-        if (featureValue__count.containsKey(featureValue)) {
-          num smoothedValueCount =
-              (featureValue__count[featureValue] + smoothingFactor);
+        num smoothedCount = countForFeatureValue + smoothingFactor;
 
-          if (smoothedValueCount < modelSwitchThreshold) {
-            // Use 'unseen estimator'
-            pFeature = (smoothedValueCount / totalSeenCount);
-            // Mark the features with an unseen case estimator
-            featureLookup =
-                featureLookup + " U_$smoothedValueCount/$totalSeenCount";
-          } else {
-            pFeature = (smoothedValueCount / totalForThisValue);
-            featureLookup =
-                featureLookup + " _$smoothedValueCount/$totalForThisValue";
-          }
+        var pFeatureValue;
+
+        // P(inClass == context[inClass] | completion == "toString") *
+        // P(... == context[...] | completion == "toString") *
+
+        if (totalCountForFeature < modelSwitchThreshold) {
+          // We haven't seen enough information for any values for this
+          // feature, revert to a uniform model
+          pFeatureValue = smoothedCount / totalCompletionsSeenForThisTarget;
+          result.featureValues["${featureName}__globalUnseen"] = pFeatureValue;
+        } else if (smoothedCount < modelSwitchThreshold) {
+          // For very small counts this will over-estimate
+          pFeatureValue = smoothingFactor / totalCompletionsSeenForThisTarget;
+          result.featureValues["${featureName}__localUnseen"] = pFeatureValue;
         } else {
-          pFeature = (smoothingFactor / totalSeenCount); // Smoothing factor
-          // Mark the features with an unseen case estimator
-          featureLookup = featureLookup + " X_$smoothingFactor/$totalSeenCount";
-
-          if (ENABLE_DIAGNOSTICS) {
-            _logger.finest("");
-
-            _logger.finest(" === Query === ");
-            _logger.finest("featureName: $featureName featureValue: $featureValue");
-
-            _logger.finest(" === Total Seen Count === ");
-            _logger.finest("$totalSeenCount");
-            _logger.finest(" === Map === ");
-            _logger.finest("$featureValue__count");
-            _logger.finest(" === containsKey === ");
-            _logger.finest("${featureValue__count.containsKey(featureValue)}");
-            _logger.finest(" === key type === ");
-            _logger.finest("${featureValue.runtimeType}");
-            _logger.finest(" === End ===");
-            _logger.finest("");
-          }
+          pFeatureValue = smoothedCount / totalCountForFeature;
+          result.featureValues[featureName] = pFeatureValue;
         }
-
-        completionScores[completion][featureLookup] = pFeature;
-        pFeatures *= pFeature;
+        score *= pFeatureValue;
       }
-      completionScores[completion]["Overall_PValue"] = pCompletion * pFeatures;
+      result.score = score;
+      results.add(result);
     }
-    return completionScores;
+
+    // Reverse sort the results
+    results.sort((r1, r2) => -1 * r1.score.compareTo(r2.score));
+    return results;
   }
 }
 
-sum(a, b) => a + b;
+class CompletionResult {
+  /// The proposed result
+  String completion;
 
-// Support methods
-// TODO(lukechurch): Refactor these to a shared library
-String _prettyPrint(Map results) {
-  StringBuffer sb = new StringBuffer();
-  _prettyPrintRecursive(results, sb, 0);
-  return sb.toString();
-}
+  /// [score] correlates with estimated probability
+  num score;
 
-_prettyPrintRecursive(Map results, StringBuffer sb, int tabs) {
-  bool lastLevel = results.values.first is! Map;
-
-  for (String k in results.keys) {
-    for (int i = 0; i < tabs; i++) sb.write("\t");
-
-    if (lastLevel) {
-      sb.writeln("$k : ${results[k]}");
-    } else {
-      sb.writeln("$k");
-      _prettyPrintRecursive(results[k], sb, tabs + 1);
-    }
-  }
-}
-
-String _diagnosticsPrint(List<String> completionOrder,
-    Map<String, Map<String, num>> completionFeatures) {
-  StringBuffer sb = new StringBuffer();
-
-  for (String completion in completionOrder) {
-    sb.writeln("$completion: ${completionOrder.indexOf(completion)}");
-    _prettyPrintRecursive(completionFeatures[completion], sb, 1);
-  }
-
-  return sb.toString();
+  // Optional aditional structure that is included in diagnostics mode
+  Map<String, num> featureValues = {};
 }

--- a/lib/completion_server/feature_server.dart
+++ b/lib/completion_server/feature_server.dart
@@ -2,436 +2,130 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+/// Adds a server component that abstracts over the source of the feature
+/// storage. Currently only reading and writing the features from disk
+/// storage is supported.
 library smart.completion_server.feature_server;
 
 import 'dart:convert';
-import 'dart:io';
-import 'dart:async';
-import 'package:path/path.dart' as path;
-import 'package:logging/logging.dart' as log;
+import 'dart:io' as io;
 
-import 'log_client.dart' as log_client;
+import 'package:smart/completion_model/feature_vector.dart';
 
-class IndexedMap<K, V> {
-  List<K> _index;
-  List<V> _values;
-
-  IndexedMap(Map<K,V> data, [List<List<K>> sharedIndecies]) {
-    if (sharedIndecies == null) sharedIndecies = [];
-
-    // See if we can reuse any of the existing indecies
-    for (List existingIndex in sharedIndecies) {
-      if (existingIndex.length == data.length
-        && data.keys.every(existingIndex.contains)) {
-          _index = existingIndex;
-          break;
-        }
-    }
-    if (_index == null) {
-      _index = data.keys.toList(growable: false)..sort();
-      sharedIndecies.add(_index);
-    }
-    _values = new List(data.length);
-    for (int i = 0; i < data.length; i++) {
-      _values[i] = data[_index[i]];
-    }
-  }
-
-  get(K key) {
-    // TODO: Replace this linear search with binary search where we have
-    // a reliable comparator.
-    int i = _index.indexOf(key);
-    if (i == -1) {
-      return null;
-    } else {
-      return _values[i];
-    }
-  }
-  get keys => _index.toList();
-  get values => _values.toList();
-}
-
-class FeatureNamesMap {
-  // static List<List<String>> _sharedFeatureIndecies = [];
-  IndexedMap<String, CompletionResultMap> _featureNamesMap;
-
-  CompletionResultMap getCompletionMapForFeature(String featureName)
-    => _featureNamesMap.get(featureName);
-
-  List<String> getFeatureNames() => _featureNamesMap.keys;
-  FeatureNamesMap(Map<String, Map<String, Map<dynamic, int>>>
-    featureName_completionResult_featureValue_count, FeatureServer server) {
-
-    Map scratch = {};
-    for (String featureName in featureName_completionResult_featureValue_count.keys) {
-      var completionResultMap = new CompletionResultMap(
-        featureName_completionResult_featureValue_count[featureName], server);
-      scratch[featureName] = completionResultMap;
-    }
-
-    _featureNamesMap = new IndexedMap(scratch, server._sharedFeatureNameIndecies);
-  }
-}
-
-class CompletionResultMap {
-  // Completion Result -> Feature Value -> Count
-  Map<String, FeatureValueMap> _featureValueMap = {};
-
-  List<String> getCompletions() => _featureValueMap.keys.toList();
-  FeatureValueMap getFeatureValueforCompletion(String completion) {
-    return _featureValueMap[completion];
-  }
-
-  CompletionResultMap(Map<String, Map<String, int>> completion_featureValue__count, FeatureServer server) {
-    for (String completionResult in completion_featureValue__count.keys) {
-      _featureValueMap[completionResult] = new FeatureValueMap(
-        completion_featureValue__count[completionResult], server
-      );
-    }
-  }
-}
-
-class FeatureValueMap {
-  FeatureServer owningServer;
-  // static List<List<String>> _sharedFeatureValueIndecies = [];
-  IndexedMap<String, int> _featureNamesMap;
-
-  List featureValues() => _featureNamesMap.keys;
-
-  int countForValue(var value) {
-    return _featureNamesMap.get(value);
-  }
-
-  FeatureValueMap(Map<dynamic, int> countMap, this.owningServer) {
-    _featureNamesMap = new IndexedMap(countMap, owningServer._sharedFeatureValueIndecies);
-  }
-}
-
-
-
-class FeaturesForType {
-  String targetType;
-  FeatureNamesMap featureNamesMap;
-
-  // Note that the breaking of Dart standard variable naming is intentional
-
-  //featureName -> completionResult -> featureValue__count
-  // Map<String, Map<String, Map<dynamic, num>>>
-  //   featureName_completionResult_featureValue_count = {};
-
-  //completionResult -> count
-  Map<String, num> completionResult_count = {};
-
-  FeaturesForType(featureName_completionResult_featureValue_count,
-      completionResult_count, FeatureServer server) {
-        this.completionResult_count = completionResult_count;
-
-        featureNamesMap =
-          new FeatureNamesMap(featureName_completionResult_featureValue_count, server);
-      }
-
-  // toJSON() {
-  //   return JSON.encode({
-  //     "targetType": targetType,
-  //     "featureName_completionResult_featureValue_count":
-  //         featureName_completionResult_featureValue_count,
-  //     "completionResult_count": completionResult_count
-  //   });
-  // }
-}
+import 'package:crypto/crypto.dart' as crypto;
 
 class FeatureServer {
-  static log.Logger _logger;
+  Map<String, Map<String, FeatureValueDistribution>>
+    _targetType_completion_featureValues =
+      <String, Map<String, FeatureValueDistribution>>{};
 
-  List<List<String>> _sharedFeatureNameIndecies = [];
-  List<List<String>> _sharedFeatureValueIndecies = [];
+  // TODO: Consider storing this in the distribution above to
+  // decrease the memory cost of the second map
+  Map<String, Map<String, int>> _completionsCount =
+    <String, Map<String, int>>{};
 
+  // Empty Model
+  FeatureServer() {}
 
-  Map<String, FeaturesForType> _featureMap = {};
-  FeaturesForType getFeaturesFor(String targetType) {
-    _logger.fine("feature_server: getFeaturesFor", targetType);
-    return _featureMap[targetType];
-  }
+  Map<String, int> getCompletionCount(String targetType)
+    => _completionsCount[targetType];
 
-  /// [completionCountJSON] is exported by the feature indexer as
-  ///  targetType_completionResult__count.json
-  ///  [featureValuesJSON] is exported exported by the feature indexer as
-  ///  targetType_feature_completionResult_featureValue__count
-  FeatureServer(String completionCountJSON, String featureValuesJSON) {
-    Stopwatch sw = new Stopwatch()..start();
-    //Target Type -> Feature -> Completion result -> Feature Value : Count
-    Map<String,Map<String,Map<String,Map<String,int>>>>
-      targetType_feature_completionResult_featureValue__count =
-        JSON.decode(featureValuesJSON);
+  Map<String, FeatureValueDistribution>
+    getCompletionFeatureValues(String targetType) =>
+     _targetType_completion_featureValues[targetType];
 
-    //Target Type -> Completion -> Count
-    Map<String, Map<String, int>> targetType_completionResult__count =
-        JSON.decode(completionCountJSON);
+  /// Method to update the model with a single feature vector
+  addFeature(FeatureVector vector) {
+    _completionsCount
+      .putIfAbsent(vector.targetType, () => {})
+      .putIfAbsent(vector.completion, () => 0);
 
-        int i = 0;
+    _completionsCount[vector.targetType][vector.completion]++;
 
-    for (String targetType in targetType_completionResult__count.keys) {
-      print ("Type progress: ${i++ / (targetType_completionResult__count.keys.length)}");
+    FeatureValueDistribution distribution =
+    _targetType_completion_featureValues
+      .putIfAbsent(vector.targetType, () => {})
+      .putIfAbsent(vector.completion, () => new FeatureValueDistribution());
 
-      FeaturesForType feature = new FeaturesForType(
-          targetType_feature_completionResult_featureValue__count[targetType],
-          targetType_completionResult__count[targetType], this);
-      _featureMap[targetType] = feature;
-    }
-
-    _logger.fine(
-        "feature_server: load from JSON:", "${sw.elapsedMilliseconds}");
-  }
-
-  exportToPackedFormat(String basePath) {
-
-    var outFile = new File(path.join(basePath, "featureVector.packed"));
-    if (outFile.existsSync()) outFile.deleteSync();
-
-
-    // Export the shared indecies
-    String featureNamesMaps_sharedFeatureIndecies = JSON.encode(
-      _sharedFeatureNameIndecies);
-
-    outFile.writeAsStringSync(
-      "featureNamesMaps_sharedFeatureIndecies: $featureNamesMaps_sharedFeatureIndecies\n"
-    , mode: FileMode.APPEND);
-
-    var featureValueMap_sharedFeatureValueIndecies = JSON.encode(
-      _sharedFeatureValueIndecies);
-
-    outFile.writeAsStringSync(
-      "featureValueMap_sharedFeatureValueIndecies: $featureValueMap_sharedFeatureValueIndecies\n"
-    , mode: FileMode.APPEND);
-
-    for (String targetType in _featureMap.keys) {
-      FeatureNamesMap featureNamesMap = _featureMap[targetType].featureNamesMap;
-
-      int locationOfFeatureNamesMapIndex =
-        _sharedFeatureNameIndecies.indexOf(
-          featureNamesMap._featureNamesMap._index
-      );
-
-      outFile.writeAsStringSync(
-        "targetType: $targetType\n"
-      , mode: FileMode.APPEND);
-
-      outFile.writeAsStringSync(
-        "locationOfFeatureNamesMapIndex: $locationOfFeatureNamesMapIndex\n"
-      , mode: FileMode.APPEND);
-
-      List<CompletionResultMap> featureNameValues =
-        featureNamesMap._featureNamesMap._values;
-
-      for (CompletionResultMap completionResultMap in featureNameValues) {
-        List completionResults = completionResultMap.getCompletions();
-
-        outFile.writeAsStringSync(
-          "completionResult: ${JSON.encode(completionResults)}\n"
-        , mode: FileMode.APPEND);
-
-        // print ("completionResult: ${JSON.encode(completionResults)}");
-
-        for (String completion in completionResults) {
-
-          FeatureValueMap featureValueMap =
-            completionResultMap.getFeatureValueforCompletion(completion);
-
-            // Location of feature value map
-            int locationOfFeatureValueMapIndex =
-              _sharedFeatureValueIndecies.indexOf(
-                featureValueMap._featureNamesMap._index
-              );
-
-              outFile.writeAsStringSync(
-                "locationOfFeatureNamesValueIndex: $locationOfFeatureValueMapIndex~"
-              , mode: FileMode.APPEND);
-
-              // print("locationOfFeatureNamesMapIndex: $locationOfFeatureValueMapIndex");
-            // Feature values result
-            var featureNamesValues =
-              featureValueMap._featureNamesMap._values;
-
-              outFile.writeAsStringSync(
-                "${JSON.encode(featureNamesValues)}\n"
-              , mode: FileMode.APPEND);
-
-              // print("featureNamesValues: ${JSON.encode(featureNamesValues)}");
-
-        }
-      }
+    for (var featureName in vector.allFeatureNames) {
+      distribution.incrementFeatureValueCount(
+        featureName, vector.getValue(featureName));
     }
   }
 
-  static Future<FeatureServer> startFromPackedPath(String basePath) async {
-    const HEADER_MARKER = true;
-
-    // _logger = new log.Logger("feature_server");
-    // log_client.bindLogServer(_logger, target: log_client.LogTarget.STDOUT);
-    // log.Logger.root.level = log.Level.ALL;
-    print("feature_server: startFromPacked: $basePath");
-    print("${new DateTime.now()}");//" ${ln.length}");
-
-
-    var inFile = new File(path.join(basePath, "featureVector.packed"));
-
-    int lnCounter = 0;
-
-    //featureNamesMaps_sharedFeatureIndecies:
-    //featureValueMap_sharedFeatureValueIndecies:
-
-    String expectStart = "targetType: ";
-
-    var featureNamesMaps_sharedFeatureIndecies;
-    var featureValueMap_sharedFeatureValueIndecies;
-
-    // State machine working variables
-    String targetType;
-    int locationOfFeatureNamesMapIndex;
-    List<String> completionResults;
-    List<int> locationOfFeatureValueMapIndex;
-    List<List<int>> featureNamesValues;
-
-    int featureCounter = 0;
-    int expectedFeatureCount;
-
-    await for (String ln in inFile.openRead().transform(UTF8.decoder).transform(new LineSplitter())) {
-
-      try {
-
-
-
-      if (lnCounter == 0) {
-        if (!ln.startsWith("featureNamesMaps_sharedFeatureIndecies: ")) throw "Structure match failure";
-
-        // Strip header marker
-        if (HEADER_MARKER) ln = ln.substring("featureNamesMaps_sharedFeatureIndecies:".length);
-        featureNamesMaps_sharedFeatureIndecies = JSON.decode(ln);
-        // print (featureNamesMaps_sharedFeatureIndecies);
-        // exit(0);
-      }
-
-      if (lnCounter == 1) {
-        if (!ln.startsWith("featureValueMap_sharedFeatureValueIndecies: ")) throw "Structure match failure";
-
-        // Strip header marker
-        if (HEADER_MARKER) ln = ln.substring("featureValueMap_sharedFeatureValueIndecies:".length);
-        featureValueMap_sharedFeatureValueIndecies = JSON.decode(ln);
-
-        print ("Shared indecies are loaded ok");
-        // print (featureNamesMaps_sharedFeatureIndecies);
-        // exit(0);
-      }
-
-      if (lnCounter > 1) {
-        print (_short(ln));
-
-        if (HEADER_MARKER && !ln.startsWith(expectStart))
-          throw "Expectation not met, expected $expectStart got ${
-            ln.substring(0, 25 > ln.length ? ln.length : 25)
-          }";
-
-        switch (expectStart) {
-          case "targetType: ":
-            targetType = ln.substring("targetType: ".length).trim();
-            expectStart = "locationOfFeatureNamesMapIndex: ";
-            break;
-
-          case "locationOfFeatureNamesMapIndex: ":
-            locationOfFeatureNamesMapIndex =
-              int.parse(ln.substring("locationOfFeatureNamesMapIndex: ".length).trim());
-
-            expectedFeatureCount = featureNamesMaps_sharedFeatureIndecies[locationOfFeatureNamesMapIndex].length;
-
-            expectStart = "completionResult: ";
-            break;
-
-          case "completionResult: ":
-            completionResults = JSON.decode(
-              ln.substring("completionResult: ".length));
-
-
-              locationOfFeatureValueMapIndex = [];
-              featureNamesValues = [];
-
-            expectStart = "locationOfFeatureNamesValueIndex: ";
-            featureCounter++;
-            break;
-
-          case "locationOfFeatureNamesValueIndex: ":
-            String text = ln.substring("locationOfFeatureNamesValueIndex: ".length);
-            locationOfFeatureValueMapIndex.add(int.parse(text.split("~")[0]));
-            featureNamesValues.add(JSON.decode(text.split("~")[1]));
-
-            print ("locationOfFeatureValueMapIndex.length: ${locationOfFeatureValueMapIndex.length}");
-            print ("featureNamesValues.length: ${featureNamesValues.length}");
-            print ("completionResults.length: ${completionResults.length}");
-
-
-            if (locationOfFeatureValueMapIndex.length ==
-              featureNamesValues.length &&
-              featureNamesValues.length == completionResults.length) {
-
-                if (featureCounter < expectedFeatureCount) {
-                  expectStart = "completionResult: ";
-                } else {
-                  featureCounter = 0;
-                  expectStart = "targetType: ";
-                }
-
-
-
-                // Done with this list
-                break;
-              }
-
-            break;
-        }
-
-        // exit(0);
-      }
-
-
-
-      lnCounter++;
-
-} catch (e, st) {
-  print (ln);
-  print (e);
-  print (st);
-  exit(1);
-}
-      // List<String> lines = inFile.readAsLinesSync();
+  /// Helper ctor to populate a feature model from a list of features
+  /// this method is not performance sensitive
+  FeatureServer.fromFeatures(Iterable<FeatureVector> features) {
+    for (var vector in features) {
+      addFeature(vector);
     }
-
-    print("${new DateTime.now()}");//" ${ln.length}");
-
-    return new Future.value(null);
   }
 
-  static FeatureServer startFromPath(String basePath) {
-    _logger = new log.Logger("feature_server");
-    log_client.bindLogServer(_logger, target: log_client.LogTarget.STDOUT);
-
-    _logger.fine("feature_server: startFromPath:", basePath);
+  FeatureServer.fromPaths(String completionCountPath, String featureValuesPath) {
     Stopwatch sw = new Stopwatch()..start();
 
-    String completionCountJSON =
-        new File(path.join(basePath, "targetType_completionResult__count.json"))
-            .readAsStringSync();
+    {
+      var file = new io.File(completionCountPath);
+      String completionCountStr = file.readAsStringSync();
+      print ("${sw.elapsedMilliseconds}: CompletionCount read from file");
 
-    String featureValuesJSON = new File(path.join(basePath,
-            "targetType_feature_completionResult_featureValue__count.json"))
-        .readAsStringSync();
+      _completionsCount = JSON.decode(completionCountStr);
+      print ("${sw.elapsedMilliseconds}: CompletionCount decoded");
+    }
 
-    _logger.info(
-        "feature_server: load from disk:", "${sw.elapsedMilliseconds}");
+    Map<String, Map<String, String>> codedFeatureValues;
+    {
+      var file = new io.File(featureValuesPath);
+      String codedFeatureValuesStr = file.readAsStringSync();
+      print ("${sw.elapsedMilliseconds}: Feature Values read from file");
+      codedFeatureValues = JSON.decode(codedFeatureValuesStr);
+    }
+    print ("${sw.elapsedMilliseconds}: Feature Values decoded");
 
-    return new FeatureServer(completionCountJSON, featureValuesJSON);
+    for (var typeStr in codedFeatureValues.keys) {
+      for (var completionStr in codedFeatureValues[typeStr].keys) {
+        var codedValue = codedFeatureValues[typeStr][completionStr];
+
+        var block = crypto.BASE64.decode(codedValue);
+
+        _targetType_completion_featureValues
+          .putIfAbsent(typeStr, () => {});
+
+          _targetType_completion_featureValues[typeStr][completionStr] =
+            new FeatureValueDistribution.fromStorageBlock(block);
+      }
+      // Allow incremental removal of the data structures to decrease peak memory usage
+      codedFeatureValues[typeStr].clear();
+    }
+    print ("${sw.elapsedMilliseconds}: Feature Values unpacked");
+
   }
 
-}
+  toPath(String completionCountPath, String featureValuesPath) {
 
-_short(String ln) {
-  return ln.substring(0, 25 > ln.length ? ln.length : 25);
+    var file = new io.File(completionCountPath);
+    if (file.existsSync()) file.deleteSync();
+
+    // Write the completions Count
+    file.writeAsStringSync(JSON.encode(_completionsCount) + "\n");
+
+    file = new io.File(featureValuesPath);
+    if (file.existsSync()) file.deleteSync();
+
+    // Encode the value distributions as UTF coded byte blocks
+    Map<String, Map<String, String>> codedFeatureValues = {};
+
+    for (var typeStr in _targetType_completion_featureValues.keys) {
+      for (var completionStr in _targetType_completion_featureValues[typeStr].keys) {
+        var codedValue =
+          crypto.BASE64.encode(
+             _targetType_completion_featureValues[typeStr][completionStr]
+               .toStorageByteBlock());
+        codedFeatureValues.putIfAbsent(typeStr, () => {});
+        codedFeatureValues[typeStr][completionStr] = codedValue;
+      }
+    }
+
+    file.writeAsStringSync(JSON.encode(codedFeatureValues) + "\n");
+  }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,8 +15,7 @@ dependencies:
   analyzer: "^0.27.0"
   logging: "^0.11.0"
   cli_util: "^0.0.1"
-  pigeon_map:
-    git: https://github.com/lukechurch/pigeon_map.git
+  crypto: "^0.9.1"
 
 dev_dependencies:
   sintr_common:


### PR DESCRIPTION
This PR changes the storage mechanism from a nested map to an indexed statically pre-defined scheme.

On the sample training set this reduces memory usage from ~6000MB to ~100MB and reduces the load time from ~240s to around ~3s at the expense of not being so self describing at runtime.

The main strategy is to statically define the feature names in a const list, the location of the feature at this index of the list is then looked up in a corresponding data structure for value counts. The value counts are loaded from typed_data structures which are Base64 encoded byte fields.

Apologies for the size of this diff, the change to the model are fairly fundamental and tend to propagate through much of the rest of the system. I need to bring this in promptly to be able to continue the experiments with dart-services, lets talk over the design later today and I'll happily follow up with more explanation and test coverage.

I wouldn't pay attention to the diff in model.dart, just consider the new code. 

TBR @emsod 

CC @danrubel @sgjesse @kempy 
